### PR TITLE
Remove plugin resolution strategy for gradle-josm-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,7 @@
 plugins {
     // uses a local development fork of the gradle josm plugin.
-    // This should be
-    //   id 'gradle-josm-plugin'
-    // but: This is a workaround for a bug in the build/publish script of the
-    // gradle-josm-plugin. If it is published to a maven repo hosted on S3,
-    // the plugin jar includes a file 'META-INF/gradle-plugins/org.openstreetmap.josm.properties'
-    // instead of a file 'META-INFO/gradle-plugins/gradle-josm-plugin.properties'.
-    // We therefore have to use the plugin ID 'org.openstreetmap.josm' instead
-    // of 'gradle-josm-plugin'.
     // See also 'settings.gradle' for additional configuration settings.
-    id 'org.openstreetmap.josm'
+    id("org.openstreetmap.josm").version("$gradle_josm_plugin_version")
     id 'java'
     id 'groovy'
     id 'eclipse'

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,19 +3,12 @@ pluginManagement {
         maven {
             // to load the gradle-josm-plugin from a custom maven repo hosted
             // on in a custom S3 bucket
-            url "$gradle_josm_plugin_repo"
-        }
-        gradlePluginPortal()
-    }
-
-    resolutionStrategy {
-        eachPlugin {
-            // WORKAROUND: we have to use the plugin ID 'org.openstreetmap.josm'
-            // instead of 'gradle-josm-plugin', see comment at the beginning
-            // of 'build.gradle'.
-            if (requested.id.id == 'org.openstreetmap.josm') {
-                useModule("org.openstreetmap.josm:gradle-josm-plugin:$gradle_josm_plugin_version")
+            url = uri(gradle_josm_plugin_repo)
+            content {
+                includeModule("org.openstreetmap.josm", "gradle-josm-plugin")
+                includeModule("org.openstreetmap.josm", "org.openstreetmap.josm.gradle.plugin")
             }
         }
+        gradlePluginPortal()
     }
 }


### PR DESCRIPTION
For me this fixes the issue https://github.com/floscher/gradle-josm-plugin/issues/10 .

Since Gradle 5.6 you can use properties to set a plugin version in the `plugins{}` block.
It is normal that you use the plugin ID `org.openstreetmap.josm` and not `gradle-josm-plugin` in the `plugins{}` block. Gradle will then based on the ID look up the artifact `org.openstreetmap.josm:org.openstreetmap.josm.gradle.plugin` in your repository, which in turn references the artifact `org.openstreetmap.josm:gradle-josm-plugin`. The latter artifact contains the plugin. That artifact is named `gradle-josm-plugin`, but the plugin ID is `org.openstreetmap.josm`.

